### PR TITLE
Fix grenade launcher ammo counts

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -129,7 +129,7 @@
 	ammo_type = /obj/item/ammo_casing/a40mm
 	max_ammo = 6
 
-/obj/item/ammo_box/magazine/internal/grenadelauncher2
+/obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher2
 	name = "grenade launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/grenade
 	caliber = "grenade"

--- a/code/modules/projectiles/guns/projectile/launchers.dm
+++ b/code/modules/projectiles/guns/projectile/launchers.dm
@@ -21,7 +21,7 @@
 	name = "grenade launcher"
 	icon_state = "grenadelauncher"
 	item_state = "gun"
-	mag_type = /obj/item/ammo_box/magazine/internal/grenadelauncher2
+	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenadelauncher2
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -7,7 +7,7 @@
 
 /obj/item/weapon/gun/projectile/revolver/New()
 	..()
-	if(!istype(magazine, /obj/item/ammo_box/magazine/internal/cylinder))
+	if(!istype(magazine, /obj/item/ammo_box/magazine/internal/cylinder) || magazine.max_ammo < 2)
 		verbs -= /obj/item/weapon/gun/projectile/revolver/verb/spin
 
 /obj/item/weapon/gun/projectile/revolver/chamber_round(var/spin = 1)


### PR DESCRIPTION
Changes grenade launcher internal magazines to be revolver type, allowing for possible rotating magazine launchers in the future, and fixing the ammo counts on the launchers.

Closes #13.