### PR TITLE
Introduce surgery failure chance for patients that feel pain and are awake

### DIFF
--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -15,7 +15,7 @@
 	var/bypass_protection = 0 //If the hypospray can go through armor or thick material
 
 	var/list/datum/reagents/reagent_list = list()
-	var/list/reagent_ids = list("salglu_solution", "epinephrine", "spaceacillin", "charcoal")
+	var/list/reagent_ids = list("salglu_solution", "epinephrine", "spaceacillin", "charcoal", "hydrocodone")
 	//var/list/reagent_ids = list("salbutamol", "silver_sulfadiazine", "styptic_powder", "charcoal", "epinephrine", "spaceacillin")
 
 /obj/item/weapon/reagent_containers/borghypo/surgeon

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -34,7 +34,7 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/weapon/screwdriver = 90
 	)
 	can_infect = 1
 	blood_level = 1
@@ -70,7 +70,7 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/bonesetter = 100,	\
-	/obj/item/weapon/wrench = 75		\
+	/obj/item/weapon/wrench = 90		\
 	)
 
 	time = 32
@@ -109,7 +109,7 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/bonesetter = 100,	\
-	/obj/item/weapon/wrench = 75		\
+	/obj/item/weapon/wrench = 90		\
 	)
 
 	time = 32

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -25,7 +25,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
 	/obj/item/weapon/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 90
 	)
 
 	time = 54
@@ -72,7 +72,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75
+	/obj/item/weapon/crowbar = 90
 	)
 
 	time = 24
@@ -123,7 +123,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75
+	/obj/item/weapon/crowbar = 90
 	)
 
 	time = 24
@@ -173,7 +173,7 @@
 	name = "mend bone"
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/weapon/screwdriver = 90
 	)
 
 	time = 24

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -29,8 +29,8 @@
 	name = "make incision"
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
 	)
 
 	time = 16
@@ -60,8 +60,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/hemostat = 100, 	\
-	/obj/item/stack/cable_coil = 75, 	\
-	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
+	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/device/assembly/mousetrap = 12	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
 	time = 24
@@ -87,8 +87,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 55,	\
-	/obj/item/weapon/kitchen/utensil/fork = 75)
+	/obj/item/weapon/crowbar = 65,	\
+	/obj/item/weapon/kitchen/utensil/fork = 90)
 
 	time = 64
 
@@ -114,9 +114,9 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 75,	\
-	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/clothing/mask/cigarette = 90,	\
+	/obj/item/weapon/lighter = 60,			\
+	/obj/item/weapon/weldingtool = 30
 	)
 
 	time = 24

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -24,13 +24,13 @@
 
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
-	/obj/item/weapon/scissors = 10,		\
-	/obj/item/weapon/twohanded/chainsaw = 1, \
-	/obj/item/weapon/claymore = 5, \
-	/obj/item/weapon/melee/energy/ = 5, \
-	/obj/item/weapon/pen/edagger = 5,  \
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
+	/obj/item/weapon/scissors = 15,		\
+	/obj/item/weapon/twohanded/chainsaw = 2, \
+	/obj/item/weapon/claymore = 6, \
+	/obj/item/weapon/melee/energy/ = 6, \
+	/obj/item/weapon/pen/edagger = 10,  \
 	)
 
 	time = 16
@@ -63,8 +63,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 75, 	\
-	/obj/item/device/assembly/mousetrap = 20
+	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/device/assembly/mousetrap = 25
 	)
 
 	time = 24
@@ -98,8 +98,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/crowbar = 90,	\
+	/obj/item/weapon/kitchen/utensil/fork = 60
 	)
 
 	time = 24
@@ -153,9 +153,9 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 75,	\
-	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/clothing/mask/cigarette = 90,	\
+	/obj/item/weapon/lighter = 60,			\
+	/obj/item/weapon/weldingtool = 30
 	)
 
 	time = 24
@@ -204,8 +204,9 @@
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
 	/obj/item/weapon/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/weapon/hatchet = 75, \
-	/obj/item/weapon/melee/arm_blade = 60
+	/obj/item/weapon/hatchet = 90, \
+	/obj/item/weapon/melee/energy/ = 90, \
+	/obj/item/weapon/melee/arm_blade = 75
 	)
 
 	time = 100

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -82,24 +82,24 @@
 			return 1
 	return 0
 
-+/proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-+	if(M.stat && !M.sleeping) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
-+		return 1
-+	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
-+		return 1
-+	if(M.reagents.has_reagent("hydrocodone"))//really good pain killer
-+		return 0.99
-+	if(M.reagents.has_reagent("morphine"))//Just as effective as Hydrocodone, but has an addiction chance
-+		return 0.99
-+	if(M.drunk >= 80)//really damn drunk
-+		return 0.95
-+	if(M.drunk >= 40)//pretty drunk
-+		return 0.9
-+	if(M.reagents.has_reagent("sal_acid")) //it's better than nothing, as far as painkillers go.
-+		return 0.85
-+	if(M.drunk >= 15)//a little drunk
-+		return 0.85
-+	return 0.8 //20% failure chance
+/proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
+	if(M.stat && !M.sleeping) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
+		return 1
+	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
+		return 1
+	if(M.reagents.has_reagent("hydrocodone"))//really good pain killer
+		return 0.99
+	if(M.reagents.has_reagent("morphine"))//Just as effective as Hydrocodone, but has an addiction chance
+		return 0.99
+	if(M.drunk >= 80)//really damn drunk
+		return 0.95
+	if(M.drunk >= 40)//pretty drunk
+		return 0.9
+	if(M.reagents.has_reagent("sal_acid")) //it's better than nothing, as far as painkillers go.
+		return 0.85
+	if(M.drunk >= 15)//a little drunk
+		return 0.85
+	return 0.8 //20% failure chance
 
 /proc/get_location_modifier(mob/M)
 	var/turf/T = get_turf(M)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -82,7 +82,24 @@
 			return 1
 	return 0
 
-
++/proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
++	if(M.stat && !M.sleeping) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
++		return 1
++	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
++		return 1
++	if(M.reagents.has_reagent("hydrocodone"))//really good pain killer
++		return 0.99
++	if(M.reagents.has_reagent("morphine"))//Just as effective as Hydrocodone, but has an addiction chance
++		return 0.99
++	if(M.drunk >= 80)//really damn drunk
++		return 0.95
++	if(M.drunk >= 40)//pretty drunk
++		return 0.9
++	if(M.reagents.has_reagent("sal_acid")) //it's better than nothing, as far as painkillers go.
++		return 0.85
++	if(M.drunk >= 15)//a little drunk
++		return 0.85
++	return 0.8 //20% failure chance
 
 /proc/get_location_modifier(mob/M)
 	var/turf/T = get_turf(M)

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -85,7 +85,7 @@
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
 	if(M.stat && !M.sleeping) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
 		return 1
-	if(NO_PAIN in M.species.species_traits)//if you don't feel pain, you can hold still
+	if(M.species.flags & NO_PAIN)//if you don't feel pain, you can hold still
 		return 1
 	if(M.reagents.has_reagent("hydrocodone"))//really good pain killer
 		return 0.99

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -83,7 +83,7 @@
 	return 0
 
 /proc/get_pain_modifier(mob/living/carbon/human/M) //returns modfier to make surgery harder if patient is conscious and feels pain
-	if(M.stat && !M.sleeping) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too. Just sleeping won't work, though.
+	if(M.stat) //stat=0 if CONSCIOUS, 1=UNCONSCIOUS and 2=DEAD. Operating on dead people is easy, too.
 		return 1
 	if(M.species.flags & NO_PAIN)//if you don't feel pain, you can hold still
 		return 1

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -74,8 +74,8 @@
 	name = "make cavity space"
 	allowed_tools = list(
 	/obj/item/weapon/surgicaldrill = 100,	\
-	/obj/item/weapon/pen = 75,	\
-	/obj/item/stack/rods = 50
+	/obj/item/weapon/pen = 90,	\
+	/obj/item/stack/rods = 60
 	)
 
 	time = 54
@@ -99,9 +99,9 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser = 100, \
 	/obj/item/weapon/cautery = 100,			\
-	/obj/item/clothing/mask/cigarette = 75,	\
-	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/clothing/mask/cigarette = 90,	\
+	/obj/item/weapon/lighter = 60,			\
+	/obj/item/weapon/weldingtool = 30
 	)
 
 	time = 24

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -175,8 +175,8 @@
 	name = "connect limb"
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/stack/cable_coil = 75, 	\
-	/obj/item/device/assembly/mousetrap = 20
+	/obj/item/stack/cable_coil = 90, 	\
+	/obj/item/device/assembly/mousetrap = 25
 	)
 	can_infect = 1
 

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -68,17 +68,17 @@
 /datum/surgery_step/internal/manipulate_organs
 	name = "manipulate organs"
 	allowed_tools = list(/obj/item/organ/internal = 100, /obj/item/weapon/reagent_containers/food/snacks/organ = 0)
-	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/kitchen/utensil/fork = 55)
+	var/implements_extract = list(/obj/item/weapon/hemostat = 100, /obj/item/weapon/kitchen/utensil/fork = 70)
 	var/implements_mend = list(/obj/item/stack/medical/bruise_pack = 20,/obj/item/stack/medical/bruise_pack/advanced = 100,/obj/item/stack/nanopaste = 100)
 	var/implements_clean = list(/obj/item/weapon/reagent_containers/dropper = 100,
-								/obj/item/weapon/reagent_containers/glass/bottle = 75,
-								/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
-								/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
-								/obj/item/weapon/reagent_containers/glass/beaker = 60,
-								/obj/item/weapon/reagent_containers/spray = 50,
-								/obj/item/weapon/reagent_containers/glass/bucket = 40)
+								/obj/item/weapon/reagent_containers/glass/bottle = 90,
+								/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 85,
+								/obj/item/weapon/reagent_containers/food/drinks/bottle = 80,
+								/obj/item/weapon/reagent_containers/glass/beaker = 75,
+								/obj/item/weapon/reagent_containers/spray = 60,
+								/obj/item/weapon/reagent_containers/glass/bucket = 50)
 	//Finish is just so you can close up after you do other things.
-	var/implements_finsh = list(/obj/item/weapon/scalpel/laser/manager = 100,/obj/item/weapon/retractor = 100 ,/obj/item/weapon/crowbar = 75)
+	var/implements_finsh = list(/obj/item/weapon/scalpel/laser/manager = 100,/obj/item/weapon/retractor = 100 ,/obj/item/weapon/crowbar = 90)
 	var/current_type
 	var/obj/item/organ/internal/I = null
 	var/obj/item/organ/external/affected = null
@@ -425,7 +425,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
 	/obj/item/weapon/melee/energy/sword/cyborg/saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 90
 	)
 
 	time = 54
@@ -453,13 +453,13 @@
 	name = "cut carapace"
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
-	/obj/item/weapon/scissors = 10,		\
-	/obj/item/weapon/twohanded/chainsaw = 1, \
-	/obj/item/weapon/claymore = 5, \
-	/obj/item/weapon/melee/energy/ = 5, \
-	/obj/item/weapon/pen/edagger = 5, \
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
+	/obj/item/weapon/scissors = 12,		\
+	/obj/item/weapon/twohanded/chainsaw = 2, \
+	/obj/item/weapon/claymore = 6, \
+	/obj/item/weapon/melee/energy/ = 6, \
+	/obj/item/weapon/pen/edagger = 10, \
 	)
 
 	time = 16
@@ -488,8 +488,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/scalpel/laser/manager = 100, \
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/crowbar = 90,	\
+	/obj/item/weapon/kitchen/utensil/fork = 60
 	)
 
 	time = 24

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -66,7 +66,7 @@
 	name = "mend internal bleeding"
 	allowed_tools = list(
 	/obj/item/weapon/FixOVein = 100, \
-	/obj/item/stack/cable_coil = 75
+	/obj/item/stack/cable_coil = 90
 	)
 	can_infect = 1
 	blood_level = 1
@@ -118,8 +118,8 @@
 	name = "remove dead tissue"
 	allowed_tools = list(
 		/obj/item/weapon/scalpel = 100,		\
-		/obj/item/weapon/kitchen/knife = 75,	\
-		/obj/item/weapon/shard = 50, 		\
+		/obj/item/weapon/kitchen/knife = 90,	\
+		/obj/item/weapon/shard = 60, 		\
 	)
 
 	can_infect = 1
@@ -167,12 +167,12 @@
 	name = "treat necrosis"
 	allowed_tools = list(
 		/obj/item/weapon/reagent_containers/dropper = 100,
-		/obj/item/weapon/reagent_containers/glass/bottle = 75,
-		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 70,
-		/obj/item/weapon/reagent_containers/food/drinks/bottle = 65,
-		/obj/item/weapon/reagent_containers/glass/beaker = 60,
-		/obj/item/weapon/reagent_containers/spray = 50,
-		/obj/item/weapon/reagent_containers/glass/bucket = 40
+		/obj/item/weapon/reagent_containers/glass/bottle = 90,
+		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass = 85,
+		/obj/item/weapon/reagent_containers/food/drinks/bottle = 80,
+		/obj/item/weapon/reagent_containers/glass/beaker = 75,
+		/obj/item/weapon/reagent_containers/spray = 60,
+		/obj/item/weapon/reagent_containers/glass/bucket = 50
 	)
 
 	can_infect = 0

--- a/code/modules/surgery/slime.dm
+++ b/code/modules/surgery/slime.dm
@@ -18,8 +18,8 @@
 /datum/surgery_step/slime/cut_flesh
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
 	)
 
 	time = 16
@@ -46,8 +46,8 @@
 /datum/surgery_step/slime/cut_innards
 	allowed_tools = list(
 	/obj/item/weapon/scalpel = 100,		\
-	/obj/item/weapon/kitchen/knife = 75,	\
-	/obj/item/weapon/shard = 50, 		\
+	/obj/item/weapon/kitchen/knife = 90,	\
+	/obj/item/weapon/shard = 60, 		\
 	)
 
 	time = 16
@@ -73,7 +73,7 @@
 /datum/surgery_step/slime/saw_core
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 90
 	)
 
 	time = 16

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -116,6 +116,11 @@
 			prob_chance = allowed_tools[implement_type]
 		prob_chance *= get_location_modifier(target)
 
+		if(!ispath(surgery.steps[surgery.status], /datum/surgery_step/robotics) && !ispath(surgery.steps[surgery.status], /datum/surgery_step/rigsuit))//Repairing robotic limbs doesn't hurt, and neither does cutting someone out of a rig
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target //typecast to human
+				prob_chance *= get_pain_modifier(H)//operating on conscious people is hard.
+
 		if(prob(prob_chance) || isrobot(user))
 			if(end_step(user, target, target_zone, tool, surgery))
 				advance = 1


### PR DESCRIPTION
Ported from ParadiseSS13/Paradise#8123

At the moment, there is no in-game reason to ever use anesthesia or allow it to be used on you for surgery, aside from RP concerns. People gleefully jump onto the table and hold relaxed conversations while bold, red messages tell them in what horrible agony they constantly are.

This PR introduces a failure chance for surgery, based on the fact that it is pretty damn hard for a patient to lie perfectly still while his skull is being sawed open.

On top of that, it should make things more interesting for antagonists that perform surgery. With the code as it is now, it is almost suspicious to insist your patient be placed under anesthesia, denying a doctor chances to for example put mindslave implants in their patients.

The exact numbers are as follows:

    Dead or unconscious patients as well as those that don't feel pain do not cause any failure chance.
    Conscious patients with hydrocodone or morphine in their bodies have a 1% failure chance and those with salicylic acid 15%.
    Ghetto anesthesia is possible with alcohol. Depending on how drunk a patient is, the failure chance can be 5%, 10% or 15%.
    Finally, without any anesthesia and no mitigating factors, the failure chance is 20%.

By now you are probably asking: But what about Vox/plasmamen/slimes, we can't anesthetize them with the tank in surgery.
There are ways beyond the anesthesia tanks to sedate a patient. You can dose them with ether or morphine in sufficient doses. You can give them hydrocodone and accept the minor failure chance. You can get them super-drunk, etc. Overall, I think the need for painkillers should have the side effect of giving the chemist some more reasons to produce more varied chemicals.