### PR TITLE
Medbot safety tweaks + epinephrine added to synthesizer

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -524,7 +524,7 @@
 		dam += list(OXY = C.getOxyLoss())
 	if((patient_status & REQ_TOX) && !C.reagents.has_reagent(treatments[TOX]))
 		dam += list(TOX = C.getToxLoss())
-	if((patient_status & REQ_CRIT) && !C.reagents.has_reagent(treatments["crit"])
+	if((patient_status & REQ_CRIT) && !C.reagents.has_reagent(treatments["crit"]))
 		dam += list("crit" = C.getToxLoss() + C.getOxyLoss() + C.getBruteLoss() + C.getFireLoss()) //Always inject epinephrine first
 
 	var/highest = 0

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -408,7 +408,7 @@
 			patient_status |= REQ_TOX
 		if((C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatments[OXY])))
 			patient_status |= REQ_OXY
-		if ((C.inCritical()) && (!C.reagents.has_reagent(treatments["crit"])))
+		if ((C.InCritical()) && (!C.reagents.has_reagent(treatments["crit"])))
 			patient_status |= REQ_CRIT
 		return patient_status
 	else

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -408,7 +408,7 @@
 			patient_status |= REQ_TOX
 		if((C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatments[OXY])))
 			patient_status |= REQ_OXY
-		if ((C.health <= config.health_threshold_crit) && (!C.reagents.has_reagent(treatments["crit"])))
+		if ((C.inCritical()) && (!C.reagents.has_reagent(treatments["crit"])))
 			patient_status |= REQ_CRIT
 		return patient_status
 	else
@@ -524,6 +524,8 @@
 		dam += list(OXY = C.getOxyLoss())
 	if((patient_status & REQ_TOX) && !C.reagents.has_reagent(treatments[TOX]))
 		dam += list(TOX = C.getToxLoss())
+	if((patient_status & REQ_CRIT) && !C.reagents.has_reagent(treatments["crit"])
+		dam += list("crit" = C.getToxLoss() + C.getOxyLoss() + C.getBruteLoss() + C.getFireLoss()) //Always inject epinephrine first
 
 	var/highest = 0
 	var/highest_key

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -609,3 +609,4 @@
 #undef REQ_TOX
 #undef REQ_OXY
 #undef REQ_VIRUS
+#undef REQ_CRIT

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -4,6 +4,7 @@
 #define REQ_TOX		4
 #define REQ_OXY		8
 #define REQ_VIRUS	16
+#define REQ_CRIT	32
 
 //medbot
 /mob/living/simple_animal/bot/medbot
@@ -47,6 +48,7 @@
 		BURN = "salglu_solution",
 		OXY = "salbutamol",
 		TOX = "charcoal",
+		"crit" = "epinephrine",
 		"virus" = "spaceacillin",
 		"evil" = "pancuronium"
 		)
@@ -406,6 +408,8 @@
 			patient_status |= REQ_TOX
 		if((C.getOxyLoss() >= (15 + heal_threshold)) && (!C.reagents.has_reagent(treatments[OXY])))
 			patient_status |= REQ_OXY
+		if ((C.health <= config.health_threshold_crit) && (!C.reagents.has_reagent(treatments["crit"])))
+			patient_status |= REQ_CRIT
 		return patient_status
 	else
 		return patient_status
@@ -456,6 +460,9 @@
 					break
 				else
 					break
+			else if (!internalsafety && !emagged) //If they already have our reagent in them, and safety is off, then just leave them be, unless we are emagged (in that case use beaker first, then "evil" treatment)
+				soft_reset()
+				return
 	if(!emagged && check_overdose(patient,reagent_id,injection_amount)) // Now we check to see if it will overdose the patient, unless we're emagged and don't care.
 		soft_reset()
 		return


### PR DESCRIPTION
- Medbots will no longer inject from their internal synthesizer if the reagent safety is off and there is a beaker loaded. This restores the old behavior when a beaker was inserted.
- Medbots can now produce epinephrine in their internal synthesizers and will inject patients in critical condition with it before any other treatment.